### PR TITLE
Improvements to Bangumi provider

### DIFF
--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/bangumi/BangumiMetadataMapper.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/bangumi/BangumiMetadataMapper.kt
@@ -106,13 +106,26 @@ class BangumiMetadataMapper(
             thumbnail = thumbnail,
         )
 
-        val books = bookRelations.map {
-            SeriesBook(
-                id = ProviderBookId(it.id.toString()),
-                number = getBookNumber(it.name),
-                name = it.name,
-                type = null,
-                edition = null
+        val books = if (bookRelations.isNotEmpty()) {
+            bookRelations.map {
+                SeriesBook(
+                    id = ProviderBookId(it.id.toString()),
+                    number = getBookNumber(it.name),
+                    name = it.name,
+                    type = null,
+                    edition = null
+                )
+            }
+        } else {
+            // Single volume series, the series subject is the book.
+            listOf(
+                SeriesBook(
+                    id = ProviderBookId(subject.id.toString()),
+                    number = BookRange(1),
+                    name = subject.name,
+                    type = null,
+                    edition = null
+                )
             )
         }
 

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/bangumi/BangumiMetadataProvider.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/bangumi/BangumiMetadataProvider.kt
@@ -53,8 +53,7 @@ class BangumiMetadataProvider(
     }
 
     override suspend fun searchSeries(seriesName: String, limit: Int): Collection<SeriesSearchResult> {
-        return client.searchSeries(seriesName).data.asSequence()
-            .filter { it.tags.none { tag -> tag.name == "漫画单行本" } }
+        return client.searchSeries(seriesName).asSequence()
             .take(limit)
             .map {
                 metadataMapper.toSearchResult(it)
@@ -63,8 +62,7 @@ class BangumiMetadataProvider(
 
     override suspend fun matchSeriesMetadata(matchQuery: MatchQuery): ProviderSeriesMetadata? {
         val searchResults = client.searchSeries(matchQuery.seriesName)
-        val matches = searchResults.data.asSequence()
-            .filter { it.tags.none { tag -> tag.name == "漫画单行本" } }
+        val matches = searchResults.asSequence()
             .filter { nameMatcher.matches(matchQuery.seriesName, listOfNotNull(it.nameCn, it.name)) }
             .toList()
 

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/bangumi/model/SubjectSearch.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/bangumi/model/SubjectSearch.kt
@@ -22,5 +22,6 @@ data class SubjectSearchData(
     val nameCn: String? = null,
     val tags: List<SubjectTag> = emptyList(),
     val rating: SubjectRating? = null,
-    val type: SubjectType? = null
+    val type: SubjectType? = null,
+    val series: Boolean
 )


### PR DESCRIPTION
- Add support for single-volume series: search or match series using Bangumi provider will work for single-volume series.
- Search and match series using Bangumi provider is not limited to the default 10 results. This makes the search slower, but fixes the issue where the correct match is not in the first 10 search results.