### PR TITLE
Improvements to cover update

### DIFF
--- a/komf-core/src/commonMain/kotlin/snd/komf/util/BookNameParser.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/util/BookNameParser.kt
@@ -5,13 +5,13 @@ import snd.komf.model.BookRange
 object BookNameParser {
     private val volumeRegexes = listOf(
         "(?i),?\\s\\(?volume\\s(?<volumeStart>[0-9]+)(,?\\s?[0-9]+,)+(?<volumeEnd>\\s?[0-9]+)\\)?".toRegex(),
-        "(?i),?\\s\\(?([vtT]|vols\\.\\s|vol\\.\\s|volume\\s)(?<volumeStart>[0-9]+([.x#][0-9]+)?)(?<volumeEnd>-[0-9]+([.x#][0-9]+)?)?\\)?".toRegex(),
+        "(?i),?\\s\\(?([vtT]|vols\\.?\\s?|vol\\.?\\s?|volume\\s)(?<volumeStart>[0-9]+([.x#][0-9]+)?)(?<volumeEnd>-[0-9]+([.x#][0-9]+)?)?\\)?".toRegex(),
         ".*第(?<volumeStart>\\d+)-?(?<volumeEnd>\\d+)?.*巻".toRegex(),
         ".*年(?:[0-9]+月)?(?:[0-9]+日)?(?<volumeStart>\\d+)-?(?<volumeEnd>\\d+)?号".toRegex(),
     )
 
     private val chapterRegexes = listOf(
-        "(?i)(\\sc|\\s?ch\\.\\s|\\s?chapter\\s|\\s?ep\\.\\s)(?<start>[0-9]+([.x#][0-9]+)?)(?<end>-[0-9]+([.x#][0-9]+)?)?".toRegex(),
+        "(?i)(\\sc|\\s?ch\\.?\\s?|\\s?chapter\\s|\\s?ep\\.\\s)(?<start>[0-9]+([.x#][0-9]+)?)(?<end>-[0-9]+([.x#][0-9]+)?)?".toRegex(),
         ".*第(?<start>\\d+(\\.\\d+)?)-?(?<end>\\d+(\\.\\d+)?)?.*話".toRegex(),
     )
     private val bookNumberRegexes = listOf(

--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/KavitaMediaServerClientAdapter.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/KavitaMediaServerClientAdapter.kt
@@ -166,8 +166,18 @@ class KavitaMediaServerClientAdapter(private val kavitaClient: KavitaClient) : M
         selected: Boolean,
         lock: Boolean
     ): MediaServerBookThumbnail? {
-        val chapter = kavitaClient.getChapter(bookId.toKavitaChapterId())
-        kavitaClient.uploadVolumeCover(chapter.volumeId, thumbnail, lock)
+        val chapterId = bookId.toKavitaChapterId()
+        val chapter = kavitaClient.getChapter(chapterId)
+
+        if (chapter.number == KavitaClient.LOOSE_LEAF_OR_DEFAULT_NUMBER.toString()) {
+            // For chapter that doesn't have valid chapter number, i.e. Single Volume chapter in Kavita,
+            // use uploadChapterCover api which updates both the chapter cover and the parent volume cover.
+            kavitaClient.uploadChapterCover(chapterId, thumbnail, lock)
+        } else {
+            // Otherwise, only update parent volume cover.
+            kavitaClient.uploadVolumeCover(chapter.volumeId, thumbnail, lock)
+        }
+
         return null
     }
 


### PR DESCRIPTION
 - Allow more flexible volume/chapter parsing: for volume name, 'vol.x', 'vol x', 'vols.x' and 'vols x' are allowed; for chapter name, 'ch.x' and 'ch x' are allowed.
- Add uploadChapterCover to KavitaClient, update chapter cover instead of volume cover for "single volume" chapters.