### PR TITLE
Change sort number update logic

### DIFF
--- a/komf-core/src/commonMain/kotlin/snd/komf/util/BookNameParser.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/util/BookNameParser.kt
@@ -59,4 +59,23 @@ object BookNameParser {
     fun getExtraData(name: String): List<String> {
         return extraDataRegex.findAll(name).mapNotNull { it.groups["extra"]?.value }.toList()
     }
+
+    fun getSortNumber(name: String): Double? {
+        val volumeNumber = getVolumes(name)?.start
+        val chapterNumberString = chapterRegexes.firstNotNullOfOrNull { it.findAll(name).lastOrNull()?.groups }?.get("start")?.value
+
+        // Try combine volume number with chapter number to get sort number.
+        // Parse chapter string and add it as the decimals to the volume number.
+        if (volumeNumber != null) {
+            val chapterDecimals = "0.${chapterNumberString?.replace(".", "") ?: "0"}".toDoubleOrNull() ?: 0.0
+            return volumeNumber + chapterDecimals
+        }
+        // No volume number but has chapter number: use chapter number as sort number,
+        // assuming they are un-collected chapters, so they should be sorted last.
+        else if (chapterNumberString != null)
+            return chapterNumberString.replace("[x#]".toRegex(), ".").toDoubleOrNull()
+        // No volume nor chapter number in the file name, try parse book number.
+        else
+            return getBookNumber(name)?.start
+    }
 }

--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/KavitaMediaServerClientAdapter.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/KavitaMediaServerClientAdapter.kt
@@ -585,6 +585,6 @@ private fun MediaServerBookMetadataUpdate.toKavitaChapterMetadataUpdate(currentC
         titleNameLocked = false,
         isbnLocked = false,
         releaseDateLocked = false,
-        sortOrderLocked = false
+        sortOrderLocked = numberSortLock ?: false
     )
 }

--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/metadata/MetadataMapper.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/metadata/MetadataMapper.kt
@@ -42,7 +42,7 @@ class MetadataMapper {
 
                 // ignore lock since we can't know if komf was the one to lock number
                 number = bookMetadata?.number?.toString(),
-                numberSort = bookMetadata?.number?.start,
+                numberSort = bookMetadata?.numberSort ?: bookMetadata?.number?.start,
 
                 // lock if number is not null; do not unlock if was locked
                 numberLock = numberLock || bookMetadata?.number != null,

--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/metadata/MetadataPostProcessor.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/metadata/MetadataPostProcessor.kt
@@ -106,17 +106,13 @@ class MetadataPostProcessor(
     }
 
     private fun orderBook(book: MediaServerBook, metadata: BookMetadata): BookMetadata {
-        val range = when (libraryType) {
-            MediaType.MANGA -> BookNameParser.getVolumes(book.name)
-                ?: BookNameParser.getChapters(book.name)
-                ?: BookNameParser.getBookNumber(book.name)
-
-            MediaType.NOVEL, MediaType.COMIC -> BookNameParser.getBookNumber(book.name)
+        val numberSort: Double? = when (libraryType) {
+            MediaType.MANGA -> BookNameParser.getSortNumber(book.name)
+            MediaType.NOVEL, MediaType.COMIC -> BookNameParser.getBookNumber(book.name)?.start
         }
 
         return metadata.copy(
-            number = range ?: metadata.number,
-            numberSort = range?.start ?: metadata.numberSort
+            numberSort = numberSort ?: metadata.numberSort
         )
     }
 


### PR DESCRIPTION
- Calculate sort number by combining volume number with chapter number when possible.
- Lock sort number if provided.
- Fix an issue where the calculated sort number is not used in the final metadata update request.