### PR TITLE
Better handling blank strings in metadata providers

### DIFF
--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/anilist/AniListMetadataMapper.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/anilist/AniListMetadataMapper.kt
@@ -72,7 +72,7 @@ class AniListMetadataMapper(
             }
         val tags = series.tags?.asSequence()
             ?.mapNotNull { tag -> tag.rank?.let { tag.name to tag.rank } }
-            ?.filter { (_, rank) -> rank >= tagsScoreThreshold }
+            ?.filter { (name, rank) -> name.isNotBlank() && rank >= tagsScoreThreshold }
             ?.sortedByDescending { (_, rank) -> rank }
             ?.take(tagsSizeLimit)
             ?.map { (name, _) -> name }
@@ -94,7 +94,7 @@ class AniListMetadataMapper(
         val metadata = SeriesMetadata(
             status = status,
             titles = titles,
-            summary = series.description?.let { Ksoup.parse(it).wholeText() },
+            summary = series.description?.let { Ksoup.parse(it).wholeText().ifBlank { null } },
             genres = series.genres ?: emptyList(),
             tags = tags,
             authors = authors ?: emptyList(),

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/bangumi/BangumiMetadataMapper.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/bangumi/BangumiMetadataMapper.kt
@@ -59,7 +59,7 @@ class BangumiMetadataMapper(
 
         val tags = subject.tags.sortedByDescending { it.count }
             .take(15)
-            .filter { it.count > 1 }
+            .filter { it.count > 1 && it.name.isNotBlank() }
             .map { it.name }
 
         val altTitles =
@@ -91,7 +91,7 @@ class BangumiMetadataMapper(
         val metadata = SeriesMetadata(
             status = status,
             titles = titles,
-            summary = subject.summary.trimIndent(),
+            summary = subject.summary.trimIndent().ifBlank { null },
             publisher = publishers.firstOrNull(),
             alternativePublishers = altPublishers.toSet() + publishers.drop(1),
             tags = tags,
@@ -146,7 +146,7 @@ class BangumiMetadataMapper(
         val tags = book.tags.asSequence()
             .sortedByDescending { it.count }
             .take(15)
-            .filter { it.count > 1 }
+            .filter { it.count > 1 && it.name.isNotBlank() }
             .map { it.name }.toSet()
 
         val infoBox = book.infobox?.associate { it.key to it } ?: emptyMap()
@@ -160,14 +160,14 @@ class BangumiMetadataMapper(
             else -> null
         }
         val metadata = BookMetadata(
-            title = book.name,
-            summary = book.summary.trimIndent(),
+            title = book.name.ifBlank { null },
+            summary = book.summary.trimIndent().ifBlank { null },
             number = bookNumber,
             numberSort = bookNumber?.start,
             releaseDate = book.date?.let { LocalDate.parse(it) },
             authors = getAuthors(infoBox),
             tags = tags,
-            isbn = isbn,
+            isbn = isbn?.ifBlank { null },
             startChapter = null,
             endChapter = null,
             thumbnail = thumbnail,

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/bookwalker/BookWalkerMapper.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/bookwalker/BookWalkerMapper.kt
@@ -51,8 +51,10 @@ class BookWalkerMapper(
 
         val metadata = SeriesMetadata(
             titles = titles,
-            summary = book.synopsis,
-            publisher = Publisher(book.publisher, PublisherType.LOCALIZED),
+            summary = book.synopsis?.ifBlank { null },
+            publisher = book.publisher.let {
+                if (it.isNotBlank()) Publisher(it, PublisherType.LOCALIZED) else null
+            },
             genres = book.genres,
             tags = emptyList(),
             totalBookCount = allBooks.size.let { if (it < 1) null else it },
@@ -73,7 +75,7 @@ class BookWalkerMapper(
                 SeriesBook(
                     id = ProviderBookId(it.id.id),
                     number = it.number,
-                    name = it.name,
+                    name = it.name.ifBlank { null },
                     type = null,
                     edition = null
                 )
@@ -85,8 +87,8 @@ class BookWalkerMapper(
 
     fun toBookMetadata(book: BookWalkerBook, thumbnail: Image? = null): ProviderBookMetadata {
         val metadata = BookMetadata(
-            title = book.name,
-            summary = book.synopsis,
+            title = book.name.ifBlank { null },
+            summary = book.synopsis?.ifBlank { null },
             number = book.number,
             releaseDate = book.availableSince,
             authors = getAuthors(book),

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/comicvine/ComicVineMetadataMapper.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/comicvine/ComicVineMetadataMapper.kt
@@ -59,7 +59,7 @@ class ComicVineMetadataMapper(
         val metadata = SeriesMetadata(
             title = SeriesTitle(volume.name, null, null),
             titles = listOf(SeriesTitle(volume.name, null, null)),
-            summary = volume.description?.let { parseDescription(it) },
+            summary = volume.description?.let { parseDescription(it).ifBlank { null } },
             publisher = volume.publisher?.name?.let { Publisher(it) },
             releaseDate = ReleaseDate(volume.startYear?.toIntOrNull(), null, null),
             links = listOf(WebLink("ComicVine", volume.siteDetailUrl)),
@@ -88,8 +88,8 @@ class ComicVineMetadataMapper(
         cover: Image?
     ): ProviderBookMetadata {
         val metadata = BookMetadata(
-            title = issue.name,
-            summary = issue.description?.let { parseDescription(it) },
+            title = issue.name?.ifBlank { null },
+            summary = issue.description?.let { parseDescription(it).ifBlank { null } },
             number = issue.issueNumber?.toDoubleOrNull()?.let { BookRange(it, it) },
             numberSort = issue.issueNumber?.toDoubleOrNull(),
             releaseDate = (issue.storeDate ?: issue.coverDate)?.let { LocalDate.parse(it) },

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/kodansha/KodanshaMetadataMapper.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/kodansha/KodanshaMetadataMapper.kt
@@ -52,7 +52,7 @@ class KodanshaMetadataMapper(
         val metadata = SeriesMetadata(
             status = status,
             titles = listOf(SeriesTitle(seriesTitle, TitleType.LOCALIZED, "en")),
-            summary = series.description?.let { parseDescription(it) },
+            summary = series.description?.let { parseDescription(it).ifBlank { null } },
             publisher = series.publisher?.let { Publisher(it, PublisherType.LOCALIZED) },
             ageRating = ageRating,
             genres = series.genres?.map { it.name } ?: emptyList(),
@@ -85,7 +85,7 @@ class KodanshaMetadataMapper(
         val author = if (book.creators?.size == 1) Author(book.creators.first().name, AuthorRole.WRITER) else null
         val metadata = BookMetadata(
             title = book.name,
-            summary = book.description?.let { parseDescription(it) },
+            summary = book.description?.let { parseDescription(it).ifBlank { null } },
             number = book.volumeNumber?.let { volumeNumber ->
                 if (volumeNumber == 0) null
                 else BookRange(volumeNumber.toDouble())

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/mal/MalMetadataMapper.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/mal/MalMetadataMapper.kt
@@ -71,7 +71,7 @@ class MalMetadataMapper(
         val metadata = SeriesMetadata(
             status = status,
             titles = titles,
-            summary = series.synopsis,
+            summary = series.synopsis?.ifBlank { null },
             genres = series.genres.map { it.name },
             authors = authors,
             publisher = null,

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/mangadex/MangaDexMetadataMapper.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/mangadex/MangaDexMetadataMapper.kt
@@ -143,7 +143,7 @@ class MangaDexMetadataMapper(
             titles = titles,
             summary = manga.attributes.description.let { descriptionMap ->
                 descriptionMap["en"] ?: descriptionMap.values.firstOrNull()
-            },
+            }?.ifBlank { null },
             genres = genres,
             tags = tags,
             authors = authors + artists,

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/mangaupdates/MangaUpdatesMetadataMapper.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/mangaupdates/MangaUpdatesMetadataMapper.kt
@@ -59,7 +59,7 @@ class MangaUpdatesMetadataMapper(
         val metadata = SeriesMetadata(
             status = status,
             titles = titles,
-            summary = series.description,
+            summary = series.description?.ifBlank { null },
             publisher = publisher,
             alternativePublishers = (originalPublishers + englishPublishers) - setOfNotNull(publisher),
             genres = series.genres.map { it.genre },

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/nautiljon/NautiljonSeriesMetadataMapper.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/nautiljon/NautiljonSeriesMetadataMapper.kt
@@ -67,7 +67,7 @@ class NautiljonSeriesMetadataMapper(
         val metadata = SeriesMetadata(
             status = status,
             titles = titles,
-            summary = series.description,
+            summary = series.description?.ifBlank { null },
             publisher = publisher,
             alternativePublishers = setOfNotNull(originalPublisher, frenchPublisher) - setOfNotNull(publisher),
             genres = series.genres,
@@ -104,7 +104,7 @@ class NautiljonSeriesMetadataMapper(
         }
 
         val metadata = BookMetadata(
-            summary = volume.description,
+            summary = volume.description?.ifBlank { null },
             number = volume.number.let { number -> BookRange(number.toDouble(), number.toDouble()) },
             releaseDate = if (seriesMetadataConfig.useOriginalPublisher) volume.originalReleaseDate else volume.frenchReleaseDate,
             authors = authors,

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/viz/VizMetadataMapper.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/viz/VizMetadataMapper.kt
@@ -43,7 +43,7 @@ class VizMetadataMapper(
         val metadata = SeriesMetadata(
             status = if (allBooks.any { it.final }) ENDED else null,
             titles = listOf(SeriesTitle(book.seriesName, LOCALIZED, "en")),
-            summary = book.description,
+            summary = book.description?.ifBlank { null },
             publisher = Publisher(book.publisher, PublisherType.LOCALIZED),
             ageRating = book.ageRating?.age,
             genres = book.genres,
@@ -76,12 +76,12 @@ class VizMetadataMapper(
 
     fun toBookMetadata(book: VizBook, thumbnail: Image? = null): ProviderBookMetadata {
         val metadata = BookMetadata(
-            title = book.name,
-            summary = book.description,
+            title = book.name.ifBlank { null },
+            summary = book.description?.ifBlank { null },
             number = book.number,
             releaseDate = book.releaseDate,
             authors = getAuthors(book),
-            isbn = book.isbn,
+            isbn = book.isbn?.ifBlank { null },
             startChapter = null,
             endChapter = null,
             thumbnail = thumbnail,

--- a/komf-core/src/commonMain/kotlin/snd/komf/providers/yenpress/YenPressMetadataMapper.kt
+++ b/komf-core/src/commonMain/kotlin/snd/komf/providers/yenpress/YenPressMetadataMapper.kt
@@ -51,7 +51,7 @@ class YenPressMetadataMapper(
                 )
             ),
             authors = authors(book.authors),
-            summary = book.description,
+            summary = book.description?.ifBlank { null },
             genres = book.genres,
             tags = emptyList(),
             releaseDate = book.releaseDate?.toReleaseDate(),
@@ -87,11 +87,11 @@ class YenPressMetadataMapper(
     fun toBookMetadata(book: YenPressBook, thumbnail: Image? = null): ProviderBookMetadata {
         val metadata = BookMetadata(
             number = book.number,
-            title = bookTitle(book.name),
+            title = book.name.let { if (it.isNotBlank()) bookTitle(it) else null },
             authors = authors(book.authors),
-            summary = book.description,
+            summary = book.description?.ifBlank { null },
             releaseDate = book.releaseDate,
-            isbn = book.isbn,
+            isbn = book.isbn?.ifBlank { null },
             startChapter = null,
             endChapter = null,
             thumbnail = thumbnail,

--- a/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/KavitaMediaServerClientAdapter.kt
+++ b/komf-mediaserver/src/commonMain/kotlin/snd/komf/mediaserver/kavita/KavitaMediaServerClientAdapter.kt
@@ -297,7 +297,7 @@ class KavitaMediaServerClientAdapter(
 
     private fun MediaServerBookMetadataUpdate.toKavitaChapterMetadataUpdate(currentChapter: KavitaChapter): KavitaChapterMetadataUpdateRequest {
         val tags = tags?.let { deduplicate(it) }?.map { KavitaTag(id = 0, title = it) }?.ifEmpty { null }
-        val webLinks = links?.joinToString(",") { it.url }?.ifEmpty { null }
+        val webLinks = links?.joinToString(",") { it.url }?.ifBlank { null }
 
         val authors = authors?.groupBy { it.role.lowercase() }
         val writers = getRoles(authors, AuthorRole.WRITER)


### PR DESCRIPTION
Convert blank strings retrieved from metadata providers to null so that they don't block the metadata field.